### PR TITLE
Handle invalid cast exceptions in Logger

### DIFF
--- a/Scripts/Static/Logger.cs
+++ b/Scripts/Static/Logger.cs
@@ -24,9 +24,8 @@ public static class Logger
         string hint = default,
         ConsoleColor color = ConsoleColor.Red,
         [CallerFilePath] string filePath = default,
-        [CallerMemberName] string memberName = default,
         [CallerLineNumber] int lineNumber = 0
-    ) => LogDetailed(LoggerOpcode.Exception, $@"[Error] {(string.IsNullOrWhiteSpace(hint) ? "" : $"'{hint}' ")}{e.Message}\n{e.StackTrace}", color, true, filePath, memberName, lineNumber);
+    ) => LogDetailed(LoggerOpcode.Exception, $@"[Error] {(string.IsNullOrWhiteSpace(hint) ? "" : $"'{hint}' ")}{e.Message}\n{e.StackTrace}", color, true, filePath, lineNumber);
 
     /// <summary>
     /// Logs a debug message that optionally contains trace information
@@ -37,9 +36,8 @@ public static class Logger
         ConsoleColor color = ConsoleColor.Magenta,
         bool trace = true,
         [CallerFilePath] string filePath = default,
-        [CallerMemberName] string memberName = default,
         [CallerLineNumber] int lineNumber = 0
-    ) => LogDetailed(LoggerOpcode.Debug, $"[Debug] {message}", color, trace, filePath, memberName, lineNumber);
+    ) => LogDetailed(LoggerOpcode.Debug, $"[Debug] {message}", color, trace, filePath, lineNumber);
 
     public static void LogMs(Action code)
     {
@@ -98,8 +96,8 @@ public static class Logger
     /// <summary>
     /// Logs a message that may contain trace information
     /// </summary>
-    private static void LogDetailed(LoggerOpcode opcode, string message, ConsoleColor color, bool trace, string filePath, string memberName, int lineNumber) =>
-            _messages.Enqueue(new LogInfo(opcode, new LogMessageTrace(message, trace, $"  at {filePath.Substring(filePath.IndexOf("Scripts\\"))}:{memberName}:{lineNumber}"), color));
+    private static void LogDetailed(LoggerOpcode opcode, string message, ConsoleColor color, bool trace, string filePath, int lineNumber) =>
+            _messages.Enqueue(new LogInfo(opcode, new LogMessageTrace(message, trace, $"  at {filePath.Substring(filePath.IndexOf("Scripts\\"))}:{lineNumber}"), color));
 
     private static void Print(object v, ConsoleColor color)
     {

--- a/Scripts/Static/Logger.cs
+++ b/Scripts/Static/Logger.cs
@@ -1,5 +1,3 @@
-using System.Reflection.Emit;
-
 namespace Sankari;
 
 public static class Logger

--- a/Scripts/Static/Logger.cs
+++ b/Scripts/Static/Logger.cs
@@ -53,7 +53,7 @@ public static class Logger
     public static bool StillWorking() => _messages.Count > 0;
 
     /// <summary>
-    /// Dequeues a LogMessage and Logs it
+    /// Dequeues a Requested Message and Logs it
     /// </summary>
     public static void Update()
     {
@@ -67,34 +67,31 @@ public static class Logger
                 Print(result.Data.Message, result.Color);
                 Console.ResetColor();
                 break;
-            case LoggerOpcode.Exception:
-                if (result.Data is LogMessageTrace)
-                {
-                    // Normally, we would use  ...is LogMessageTrace data,
-                    // but scoping affects the other switch statements
-                    var data = result.Data as LogMessageTrace;
-                    GameManager.Console.AddMessage(data.Message);
-                    PrintErr(data.Message, result.Color);
-                    if (data.ShowTrace)
-                    {
-                        PrintErr(data.TracePath, ConsoleColor.DarkGray);
-                    }
-                    Console.ResetColor();
-                }
-                break;
-            case LoggerOpcode.Debug:
-                if (result.Data is LogMessageTrace)
-                {
-                    var data = result.Data as LogMessageTrace;
-                    GameManager.Console.AddMessage(data.Message);
-                    Print(data.Message, result.Color);
-                    if (data.ShowTrace)
-                    {
-                        Print(data.TracePath, ConsoleColor.DarkGray);
-                    }
-                    Console.ResetColor();
-                }
 
+            case LoggerOpcode.Exception:
+                GameManager.Console.AddMessage(result.Data.Message);
+                PrintErr(result.Data.Message, result.Color);
+                if (result.Data is LogMessageTrace exceptionData)
+                {
+                    if (exceptionData.ShowTrace)
+                    {
+                        PrintErr(exceptionData.TracePath, ConsoleColor.DarkGray);
+                    }
+                }
+                Console.ResetColor();
+                break;
+
+            case LoggerOpcode.Debug:
+                GameManager.Console.AddMessage(result.Data.Message);
+                Print(result.Data.Message, result.Color);
+                if (result.Data is LogMessageTrace debugData)
+                {
+                    if (debugData.ShowTrace)
+                    {
+                        Print(debugData.TracePath, ConsoleColor.DarkGray);
+                    }
+                }
+                Console.ResetColor();
                 break;
         }
     }


### PR DESCRIPTION
Problem Summary: 
 
Logger.cs uses explit casts whcih can result in [runtime errors](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/types/casting-and-type-conversions#type-conversion-exceptions-at-run-time). Logger shouldn't cause exceptions, so let's handle that.

Proposed Fix:

Logger.cs will use is casts which will return null when the cast fails instead of an exception.
