### PR TITLE
Fix Raycasts on Enemy prefab

### DIFF
--- a/Scenes/Prefabs/Enemies/BasicEnemy.tscn
+++ b/Scenes/Prefabs/Enemies/BasicEnemy.tscn
@@ -1,88 +1,84 @@
-[gd_scene load_steps=12 format=2]
+[gd_scene load_steps=12 format=3 uid="uid://b7c2qsddgvoyc"]
 
-[ext_resource path="res://Scripts/Enemy/BasicEnemy.cs" type="Script" id=1]
-[ext_resource path="res://Sprites/Level/Enemies/orange_ball.png" type="Texture2D" id=2]
+[ext_resource type="Script" path="res://Scripts/Enemy/BasicEnemy.cs" id="1"]
+[ext_resource type="Texture2D" uid="uid://beudfgktht2al" path="res://Sprites/Level/Enemies/orange_ball.png" id="2"]
 
-[sub_resource type="AtlasTexture" id=13]
-atlas = ExtResource( 2 )
-region = Rect2( 0, 0, 16, 16 )
+[sub_resource type="AtlasTexture" id="13"]
+atlas = ExtResource("2")
+region = Rect2(0, 0, 16, 16)
 
-[sub_resource type="AtlasTexture" id=14]
-atlas = ExtResource( 2 )
-region = Rect2( 16, 0, 16, 16 )
+[sub_resource type="AtlasTexture" id="14"]
+atlas = ExtResource("2")
+region = Rect2(16, 0, 16, 16)
 
-[sub_resource type="AtlasTexture" id=15]
-atlas = ExtResource( 2 )
-region = Rect2( 32, 0, 16, 16 )
+[sub_resource type="AtlasTexture" id="15"]
+atlas = ExtResource("2")
+region = Rect2(32, 0, 16, 16)
 
-[sub_resource type="AtlasTexture" id=16]
-atlas = ExtResource( 2 )
-region = Rect2( 48, 0, 16, 16 )
+[sub_resource type="AtlasTexture" id="16"]
+atlas = ExtResource("2")
+region = Rect2(48, 0, 16, 16)
 
-[sub_resource type="AtlasTexture" id=17]
-atlas = ExtResource( 2 )
-region = Rect2( 64, 0, 16, 16 )
+[sub_resource type="AtlasTexture" id="17"]
+atlas = ExtResource("2")
+region = Rect2(64, 0, 16, 16)
 
-[sub_resource type="AtlasTexture" id=18]
-atlas = ExtResource( 2 )
-region = Rect2( 80, 0, 16, 16 )
+[sub_resource type="AtlasTexture" id="18"]
+atlas = ExtResource("2")
+region = Rect2(80, 0, 16, 16)
 
-[sub_resource type="SpriteFrames" id=19]
-animations = [ {
-"frames": [ SubResource( 13 ), SubResource( 14 ), SubResource( 15 ), SubResource( 16 ), SubResource( 17 ), SubResource( 18 ) ],
+[sub_resource type="SpriteFrames" id="19"]
+animations = [{
+"frames": [SubResource("13"), SubResource("14"), SubResource("15"), SubResource("16"), SubResource("17"), SubResource("18")],
 "loop": true,
-"name": "default",
+"name": &"default",
 "speed": 5.0
-} ]
+}]
 
-[sub_resource type="RectangleShape2D" id=11]
-extents = Vector2( 16, 16 )
+[sub_resource type="RectangleShape2D" id="11"]
+size = Vector2(32, 32)
 
-[sub_resource type="CircleShape2D" id=20]
+[sub_resource type="CircleShape2D" id="20"]
 radius = 18.0
 
 [node name="CharacterBody2D" type="CharacterBody2D"]
 collision_layer = 2
 collision_mask = 2
-script = ExtResource( 1 )
+script = ExtResource("1")
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
-scale = Vector2( 2, 2 )
-frames = SubResource( 19 )
+scale = Vector2(2, 2)
+frames = SubResource("19")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-shape = SubResource( 11 )
+shape = SubResource("11")
 one_way_collision = true
 
 [node name="Wall Checks" type="Node2D" parent="."]
 
 [node name="Left" type="RayCast2D" parent="Wall Checks"]
-position = Vector2( -16, 13 )
-enabled = true
-cast_to = Vector2( -6, 0 )
+position = Vector2(-16, 13)
+target_position = Vector2(-6, 0)
 collision_mask = 3
 
 [node name="Right" type="RayCast2D" parent="Wall Checks"]
-position = Vector2( 16, 13 )
-enabled = true
-cast_to = Vector2( 6, 0 )
+position = Vector2(16, 13)
+target_position = Vector2(6, 0)
 collision_mask = 3
 
 [node name="Cliff Checks" type="Node2D" parent="."]
 
 [node name="Left" type="RayCast2D" parent="Cliff Checks"]
-position = Vector2( -17, 16 )
-enabled = true
-cast_to = Vector2( 0, 7 )
+position = Vector2(-17, 16)
+target_position = Vector2(0, 7)
 collision_mask = 3
 
 [node name="Right" type="RayCast2D" parent="Cliff Checks"]
-position = Vector2( 17, 16 )
-enabled = true
-cast_to = Vector2( 0, 7 )
+position = Vector2(17, 16)
+target_position = Vector2(0, 7)
 collision_mask = 3
 
 [node name="Enemy" type="Area2D" parent="." groups=["Enemy"]]
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Enemy"]
-shape = SubResource( 20 )
+shape = SubResource("20")


### PR DESCRIPTION
Problem: Conversion to Godot 4 has a different structure for .tscn files. This reveals itself in the ray casts of the enemy prefab.

Fortunately, it seems to only have affected 1 prefab (other's look a bit weird, but it might just be the new way these are displayed in the editor). Also, there aren't many, so we don't need to create a tool for this.

See #125.

Solution: Manually update the ray casts.

Note: The other changes were done automatically by the editor.