### PR TITLE
Update some logic between commands and player to address ideas and concerns from PR #164

### DIFF
--- a/Scripts/Entities/Commands/EntityCommandWallJumps.cs
+++ b/Scripts/Entities/Commands/EntityCommandWallJumps.cs
@@ -21,13 +21,14 @@ public interface IEntityWallJumpable : IEntityMoveable
 	bool IsFalling();
 
 	// Force the entity to jump
-	void Jump();	
+	void Jump();
 }
+
 public class EntityCommandWallJumps : EntityCommand<IEntityWallJumpable>
 {
 	public EntityCommandWallJumps(IEntityWallJumpable entity) : base(entity) { }
 
-	public override void Update(MovementInput input)
+	public override void Start()
 	{
 		var velocity = Entity.Velocity;
 		// on a wall and falling
@@ -40,16 +41,13 @@ public class EntityCommandWallJumps : EntityCommand<IEntityWallJumpable>
 				velocity.y = 0;
 
 				// fast fall
-				if (input.IsDown)
+				if (MovementUtils.IsDown(Entity.MoveDir))
 					velocity.y += 50;
 
 				// wall jump
-				if (input.IsJump)
-				{
-					Entity.Jump();
-					velocity.x += -Entity.JumpForceWallHorz * Entity.WallDir;
-					velocity.y -= Entity.JumpForceWallVert;
-				}
+				Entity.Jump();
+				velocity.x += -Entity.JumpForceWallHorz * Entity.WallDir;
+				velocity.y -= Entity.JumpForceWallVert;
 			}
 		}
 		else

--- a/Scripts/Entities/Commands/EntityCommands.cs
+++ b/Scripts/Entities/Commands/EntityCommands.cs
@@ -16,7 +16,6 @@ public interface IEntityMoveable
 
 	// Timers object that can be used to make timers
 	public GTimers Timers { get; }
-
 }
 
 public abstract class EntityCommand
@@ -42,7 +41,13 @@ public abstract class EntityCommand
 	{ }
 
 	/// <summary>
-	/// Called when there's a need to prematurely stop the Movement
+	/// Start the command
+	/// </summary>
+	public virtual void Start()
+	{ }
+
+	/// <summary>
+	/// Stop the command
 	/// </summary>
 	public virtual void Stop()
 	{ }
@@ -56,5 +61,4 @@ public abstract class EntityCommand<T> : EntityCommand
 	{
 		Entity = entity;
 	}
-
 }

--- a/Scripts/Entities/Player/MovementUtils.cs
+++ b/Scripts/Entities/Player/MovementUtils.cs
@@ -24,4 +24,22 @@ public class MovementUtils
 			IsSprint = Input.IsActionPressed("player_sprint"),
 		};
 	}
+
+	/// <summary>
+	/// Check if a given vector is pointing upwards
+	/// </summary>
+	/// <returns>True if the vector is pointing upwards</returns>
+	public static bool IsUp(Vector2 vector)
+	{
+		return vector.y < 0;
+	}
+
+	/// <summary>
+	/// Check if a given vector is pointing downwards
+	/// </summary>
+	/// <returns>True if the vector is pointing downwards</returns>
+	public static bool IsDown(Vector2 vector)
+	{
+		return vector.y > 0;
+	}
 }

--- a/Scripts/Entities/Player/Player.cs
+++ b/Scripts/Entities/Player/Player.cs
@@ -298,8 +298,7 @@ public partial class Player : CharacterBody2D, IPlayerSkills
 	{
 		if (this.GlobalPosition.x < area.GlobalPosition.x)
 			return -1;
-		else
-			if (this.GlobalPosition.x > area.GlobalPosition.x)
+		else if (this.GlobalPosition.x > area.GlobalPosition.x)
 			return 1;
 
 		return 0;


### PR DESCRIPTION
Cleaned up some logic from PR #164.

Stop was a pretty good idea, so added Start. This way the consumer can start and stop the command at will and the command doesn't care what the input is bound to... While this does apply to Dash and WallJump, the future applications are more interesting. If we have player actions (e.g. grapple hook), the command doesn't need to check input to see if it needs to trigger. Instead the consumer will call the function.

Attempting to remove the dependency of input. Not sure if it's a good idea to have it yet. We really should make it entity agnostic which is why I'm leaning into MoveDir.

Accessing an array to stop a dash is a bit messy. Instead let's have a internal class to track commands. This way we can call "CommandDash" instead of [0].