### PR TITLE
Health bar bug fix

### DIFF
--- a/Scripts/Entities/Player/Player.cs
+++ b/Scripts/Entities/Player/Player.cs
@@ -304,7 +304,7 @@ public partial class Player : CharacterBody2D, IPlayerSkills
 		return 0;
 	}
 
-	public void TakenDamage(int side, float damage)
+	public void TakenDamage(int side, int damage)
 	{
 		if (!GameManager.LevelUI.RemoveHealth(damage))
 			Died();
@@ -400,7 +400,7 @@ public partial class Player : CharacterBody2D, IPlayerSkills
 
 		if (area.IsInGroup("Enemy"))
 		{
-			TakenDamage(GetCollisionSide(area), 0.5f);
+			TakenDamage(GetCollisionSide(area), 1);
 			return;
 		}
 

--- a/Scripts/Managers/LevelUIManager.cs
+++ b/Scripts/Managers/LevelUIManager.cs
@@ -29,7 +29,7 @@ public partial class LevelUIManager : Control
         ControlLives = GetNode<Control>(NodePathControlLives);
 		HealthBar = GetNode<HBoxContainer>(NodePathHealthBar);
 
-		AddHealth((float)3);
+		AddHealth(3);
         CoinSprite.Playing = true;
         ControlLives.Hide();
     }
@@ -52,9 +52,10 @@ public partial class LevelUIManager : Control
 
     public void RemoveLife()
     {
-		AddHealth((float)3);
+		RemoveHealth(Health);
+		AddHealth(3);
+		GD.Print(Health);
 		Lives--;
-
         LabelLives.Text = "" + Lives;
     }
 
@@ -65,23 +66,20 @@ public partial class LevelUIManager : Control
     }
 
 	/// <summary>
-	/// Adds teh specified amount of health
+	/// Adds the specified amount of health
 	/// </summary>
 	/// /// <param name="amount">Amount of health to add</param>
 	public void AddHealth(float amount = 1)
 	{
-		Health += amount;
-
 		var textureFullHeart = GD.Load<Texture2D>("res://Sprites/icon.png");
 		var textureHalfHeart = GD.Load<Texture2D>("res://Sprites/light.png");
 
-		var j = 0;
-
-		for (var i = 0.5f; i <= amount; i += 0.5f, j++)
+		var j = Health*2; //Health is literally a halved index of visible sprites
+		for (var i = Health + 0.5f; i <= Health + amount; i += 0.5f, j++) //adding 'Health' is required due to the nature of the usage of 'i'
 		{
-			if ((2 * i) % 2 == 0) // 'i' is an int
+			if ((2 * i) % 2 == 0) // if 'i' is an int
 			{
-				HealthBar.GetChild<Sprite2D>(j - 1).Hide();
+				HealthBar.GetChild<Sprite2D>((int)j - 1).Hide();
 
 				if (HealthBar.GetChildCount() <= j)
 					AddHealthSprite(textureFullHeart, new Vector2(50 * (i - 1), 40));
@@ -97,8 +95,9 @@ public partial class LevelUIManager : Control
 				}
 			}
 
-			HealthBar.GetChild<Sprite2D>(j).Show();
+			HealthBar.GetChild<Sprite2D>((int)j).Show();
 		}
+		Health += amount;
 	}
 
 	private void AddHealthSprite(Texture2D texture, Vector2 position) 
@@ -106,7 +105,7 @@ public partial class LevelUIManager : Control
 		var sprite = new Sprite2D() 
 		{
 			Texture = texture,
-			Scale = new Vector2((float)48 / texture.GetWidth(), (float)48 / texture.GetHeight()), // what is so special about 48 anyways?
+			Scale = new Vector2((float)48 / texture.GetWidth(), (float)48 / texture.GetHeight()), // 48 looks good as a size (64 was too big, 32 too small)
 			Position = position
 		};
 

--- a/Scripts/Managers/LevelUIManager.cs
+++ b/Scripts/Managers/LevelUIManager.cs
@@ -54,7 +54,6 @@ public partial class LevelUIManager : Control
     {
 		RemoveHealth(Health);
 		AddHealth(3);
-		GD.Print(Health);
 		Lives--;
         LabelLives.Text = "" + Lives;
     }

--- a/Scripts/Managers/LevelUIManager.cs
+++ b/Scripts/Managers/LevelUIManager.cs
@@ -19,7 +19,7 @@ public partial class LevelUIManager : Control
 
     private int Coins { get; set; }
     private int Lives { get; set; } = 3;
-	private float Health { get; set; } = 0;
+	private int Health { get; set; } = 0;
 
     public override void _Ready()
     {
@@ -29,7 +29,7 @@ public partial class LevelUIManager : Control
         ControlLives = GetNode<Control>(NodePathControlLives);
 		HealthBar = GetNode<HBoxContainer>(NodePathHealthBar);
 
-		AddHealth(3);
+		AddHealth(6);
         CoinSprite.Playing = true;
         ControlLives.Hide();
     }
@@ -55,7 +55,7 @@ public partial class LevelUIManager : Control
 		if(Lives-- > 0)
 		{
 			RemoveHealth(Health);
-			AddHealth(3);
+			AddHealth(6);
 		}
         LabelLives.Text = "" + Lives;
     }
@@ -70,33 +70,33 @@ public partial class LevelUIManager : Control
 	/// Adds the specified amount of health
 	/// </summary>
 	/// /// <param name="amount">Amount of health to add</param>
-	public void AddHealth(float amount = 1)
+	public void AddHealth(int amount = 2)
 	{
 		var textureFullHeart = GD.Load<Texture2D>("res://Sprites/icon.png");
 		var textureHalfHeart = GD.Load<Texture2D>("res://Sprites/light.png");
 
-		var j = Health * 2; //Health is literally a halved index of visible sprites
-		for (var i = Health + 0.5f; i <= Health + amount; i += 0.5f, j++) //adding 'Health' is required due to the nature of the usage of 'i'
+		//Health is literally an index of visible sprites
+		for (var spriteIndex = Health; spriteIndex < Health + amount; spriteIndex++)
 		{
-			if ((2 * i) % 2 == 0) // if 'i' is an int
+			if (spriteIndex % 2 != 0)
 			{
-				HealthBar.GetChild<Sprite2D>((int)j - 1).Hide();
+				HealthBar.GetChild<Sprite2D>(spriteIndex - 1).Hide();
 
-				if (HealthBar.GetChildCount() <= j)
-					AddHealthSprite(textureFullHeart, new Vector2(50 * (i - 1), 40));
+				if (HealthBar.GetChildCount() <= spriteIndex)
+					AddHealthSprite(textureFullHeart, new Vector2(50 * (spriteIndex - 1)*0.5f, 40));
 			}
 			else
 			{
-				if (HealthBar.GetChildCount() <= j)
+				if (HealthBar.GetChildCount() <= spriteIndex)
 				{
-					AddHealthSprite(textureHalfHeart, new Vector2(50 * (int)i, 40));
+					AddHealthSprite(textureHalfHeart, new Vector2(50 * spriteIndex*0.5f, 40));
 
 					HealthBar.GlobalPosition = new Vector2(HealthBar.GlobalPosition.x - 50, HealthBar.GlobalPosition.y);
-					HealthBar.Size = new Vector2(50 * ((int)i + 1), 48);
+					HealthBar.Size = new Vector2(50 * (spriteIndex+1), 48);
 				}
 			}
 
-			HealthBar.GetChild<Sprite2D>((int)j).Show();
+			HealthBar.GetChild<Sprite2D>(spriteIndex).Show();
 		}
 		Health += amount;
 	}
@@ -117,11 +117,11 @@ public partial class LevelUIManager : Control
 	/// If is able to substract some health True otherwise False
 	/// </summary>
 	/// <param name="amount">Amount of health to substract</param>
-	public bool RemoveHealth(float amount = 0.5f)
+	public bool RemoveHealth(int amount = 1)
 	{
 		if ((Health -= amount) <= 0)
 		{
-			for (var i = HealthBar.GetChildCount() - 1; i >= 0; i--)
+			for (int i = HealthBar.GetChildCount() - 1; i >= 0; i--)
 			{
 				var curHeart  = HealthBar.GetChild<Sprite2D>(i);
 
@@ -135,7 +135,7 @@ public partial class LevelUIManager : Control
 		}
 		else
 		{
-			var c = 2 * amount;
+			var c = amount;
 
 			for (var i = HealthBar.GetChildCount() - 1; i >= 0 && c > 0; i--)
 			{

--- a/Scripts/Managers/LevelUIManager.cs
+++ b/Scripts/Managers/LevelUIManager.cs
@@ -52,9 +52,11 @@ public partial class LevelUIManager : Control
 
     public void RemoveLife()
     {
-		RemoveHealth(Health);
-		AddHealth(3);
-		Lives--;
+		if(Lives-- > 0)
+		{
+			RemoveHealth(Health);
+			AddHealth(3);
+		}
         LabelLives.Text = "" + Lives;
     }
 
@@ -73,7 +75,7 @@ public partial class LevelUIManager : Control
 		var textureFullHeart = GD.Load<Texture2D>("res://Sprites/icon.png");
 		var textureHalfHeart = GD.Load<Texture2D>("res://Sprites/light.png");
 
-		var j = Health*2; //Health is literally a halved index of visible sprites
+		var j = Health * 2; //Health is literally a halved index of visible sprites
 		for (var i = Health + 0.5f; i <= Health + amount; i += 0.5f, j++) //adding 'Health' is required due to the nature of the usage of 'i'
 		{
 			if ((2 * i) % 2 == 0) // if 'i' is an int


### PR DESCRIPTION
Found a bug in the health bar, which I didn't see. Basically, when adding several times some health the "Health" variable was updated, but the new health was put above the old ones in the bar (so an incorrect update here). Also I redid a little the health bar behaviour on the player death (before due to my mistake and an old prototype it just added, now it first removes all the health and adds the default one).
I also have a proposition to put the health bar on the left (upper angle instead of coins or lower angle) as in such way it will look more natural and it will be possible to remove the changing of the globalPosition of the health bar (otherwise I can try to redo it to behave on the right, i.e. the health will be subtracted from the left and not from the right as we have now)