### PR TITLE
Fix for .remap error when loading maps on exported linux builds. See …

### DIFF
--- a/Scripts/Static/LevelManager.cs
+++ b/Scripts/Static/LevelManager.cs
@@ -1,3 +1,5 @@
+using System.Runtime.InteropServices;
+
 namespace Sankari;
 
 public static class LevelManager
@@ -14,16 +16,15 @@ public static class LevelManager
     {
         NodeLevel = nodeLevel;
 
-		GodotFileManager.LoadDir("Scenes/Levels", (dir, fileName) =>
+		GodotFileManager.LoadDir("Scenes/Levels", (dir, fileName) => 
 		{
-			if (!dir.CurrentIsDir())
-			{
-				GD.Print(fileName);
+			// This is here because of a Godot issue (https://github.com/godotengine/godot/issues/66014)
+			// for linux users. If this gets fixed, this code should be deleted.
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
 				fileName  = fileName.Replace(".tscn.remap", ".tscn");
-				Scenes[fileName.Replace(".tscn", "")] =
-					ResourceLoader.Load<PackedScene>($"res://Scenes/Levels/{fileName}");
-				GD.Print(Scenes.PrintFull());
-			}
+
+			if (!dir.CurrentIsDir())
+				Scenes[fileName.Replace(".tscn", "")] = ResourceLoader.Load<PackedScene>($"res://Scenes/Levels/{fileName}");
 		});
 
 		// test level

--- a/Scripts/Static/LevelManager.cs
+++ b/Scripts/Static/LevelManager.cs
@@ -17,7 +17,13 @@ public static class LevelManager
 		GodotFileManager.LoadDir("Scenes/Levels", (dir, fileName) =>
 		{
 			if (!dir.CurrentIsDir())
-				Scenes[fileName.Replace(".tscn", "")] = ResourceLoader.Load<PackedScene>($"res://Scenes/Levels/{fileName}");
+			{
+				GD.Print(fileName);
+				fileName  = fileName.Replace(".tscn.remap", ".tscn");
+				Scenes[fileName.Replace(".tscn", "")] =
+					ResourceLoader.Load<PackedScene>($"res://Scenes/Levels/{fileName}");
+				GD.Print(Scenes.PrintFull());
+			}
 		});
 
 		// test level
@@ -60,7 +66,7 @@ public static class LevelManager
 
         // load level
         var scenePath = $"res://Scenes/Levels/{CurrentLevel}.tscn";
-        if (!FileAccess.FileExists(scenePath))
+        if (!FileAccess.FileExists(scenePath) && !FileAccess.FileExists(scenePath + ".remap"))
         {
             Logger.LogWarning("Level has not been made yet!");
             return;


### PR DESCRIPTION
…https://github.com/godotengine/godot/issues/66014 This might be fixed by Godot in the future and this change should be reverted