### PR TITLE
Change Player Wall Jumping

### DIFF
--- a/Scenes/Prefabs/Player.tscn
+++ b/Scenes/Prefabs/Player.tscn
@@ -27,21 +27,21 @@ shape = SubResource("1")
 
 [node name="RayCast2D" type="RayCast2D" parent="Raycasts/Wall Checks/Left"]
 position = Vector2(-10, -12)
-target_position = Vector2(-5, 0)
+target_position = Vector2(-3, 0)
 
 [node name="RayCast2D2" type="RayCast2D" parent="Raycasts/Wall Checks/Left"]
 position = Vector2(-10, 3)
-target_position = Vector2(-5, 0)
+target_position = Vector2(-3, 0)
 
 [node name="Right" type="Node2D" parent="Raycasts/Wall Checks"]
 
 [node name="RayCast2D" type="RayCast2D" parent="Raycasts/Wall Checks/Right"]
 position = Vector2(10, -12)
-target_position = Vector2(5, 0)
+target_position = Vector2(3, 0)
 
 [node name="RayCast2D2" type="RayCast2D" parent="Raycasts/Wall Checks/Right"]
 position = Vector2(10, 3)
-target_position = Vector2(5, 0)
+target_position = Vector2(3, 0)
 
 [node name="Ground Checks" type="Node2D" parent="Raycasts"]
 

--- a/Scripts/Entities/Animations/EntityAnimationIdle.cs
+++ b/Scripts/Entities/Animations/EntityAnimationIdle.cs
@@ -9,6 +9,7 @@ public class EntityAnimationIdle : EntityAnimation<IEntityAnimation>
 	public override void EnterState()
 	{
 		Entity.AnimatedSprite.Play("idle");
+		HandleStateTransitions();
 	}
 
 	public override void UpdateState()
@@ -35,9 +36,10 @@ public class EntityAnimationIdle : EntityAnimation<IEntityAnimation>
 					else
 						SwitchState(EntityAnimationType.Walking);
 			}
-			else
-			if (player.IsFalling())
+			else if (player.IsFalling())
 				SwitchState(EntityAnimationType.JumpFall);
+			else if (player.Velocity.y != 0)
+				SwitchState(EntityAnimationType.JumpStart);
 		}
 	}
 

--- a/Scripts/Entities/Animations/EntityAnimationJumpFall.cs
+++ b/Scripts/Entities/Animations/EntityAnimationJumpFall.cs
@@ -35,6 +35,9 @@ public class EntityAnimationJumpFall : EntityAnimation<IEntityAnimation>
 					SwitchState(EntityAnimationType.Idle);
 			else if (player.PlayerInput.IsDash)
 				SwitchState(EntityAnimationType.Dash);
+			else if (!player.IsFalling() && player.Velocity.y != 0)
+				SwitchState(EntityAnimationType.JumpStart);
+
 		}
 	}
 

--- a/Scripts/Entities/Animations/EntityAnimationRunning.cs
+++ b/Scripts/Entities/Animations/EntityAnimationRunning.cs
@@ -38,7 +38,7 @@ public class EntityAnimationRunning : EntityAnimation<IEntityAnimation>
 
 				SwitchState(EntityAnimationType.Walking);
 
-			else if (Entity.MoveDir == Vector2.Zero)
+			else if (Entity.MoveDir == Vector2.Zero || (player.Velocity.y != 0))
 
 				SwitchState(EntityAnimationType.Idle);
 		}

--- a/Scripts/Entities/Animations/EntityAnimationWalking.cs
+++ b/Scripts/Entities/Animations/EntityAnimationWalking.cs
@@ -37,7 +37,7 @@ public class EntityAnimationWalking : EntityAnimation<IEntityAnimation>
 
 				SwitchState(EntityAnimationType.Running);
 
-			else if (player.MoveDir == Vector2.Zero)
+			else if (player.MoveDir == Vector2.Zero || player.Velocity.y != 0)
 
 				SwitchState(EntityAnimationType.Idle);
 		}

--- a/Scripts/Entities/Commands/EntityCommand.cs
+++ b/Scripts/Entities/Commands/EntityCommand.cs
@@ -16,7 +16,7 @@ public interface IEntityMoveable : IEntityBase
 	public Vector2 Velocity { get; set; }
 
 	// Position in the world
-	public Vector2 GlobalPosition { get; }
+	public Vector2 GlobalPosition { get; set; }
 
 	// Connection to the game world
 	public Window Tree { get; }

--- a/Scripts/Entities/Commands/EntityCommandMovement.cs
+++ b/Scripts/Entities/Commands/EntityCommandMovement.cs
@@ -12,7 +12,7 @@ public class EntityCommandMovement : EntityCommand<IEntityMovement>
 	public int MaxSpeedWalk     { get; set; } = 350;
 	public int MaxSpeedSprint   { get; set; } = 500;
 	public int MaxSpeedAir      { get; set; } = 350;
-	public int AirAcceleration  { get; set; } = 20;
+	public int AirAcceleration  { get; set; } = 30;
 	public int DampeningAir     { get; set; } = 10;
 	public int DampeningGround  { get; set; } = 25;
 

--- a/Scripts/Entities/Commands/EntityCommandWallJump.cs
+++ b/Scripts/Entities/Commands/EntityCommandWallJump.cs
@@ -3,7 +3,7 @@
 public interface IEntityWallJumpable : IEntityMoveable
 {
 	// Left wall checks
-	public List<RayCast2D> RayCast2DWallChecksLeft  { get; }
+	public List<RayCast2D> RayCast2DWallChecksLeft { get; }
 
 	// Right wall checks
 	public List<RayCast2D> RayCast2DWallChecksRight { get; }
@@ -23,6 +23,7 @@ public interface IEntityWallJumpable : IEntityMoveable
 	// Vertical wall jump force
 	public int JumpForceWallVert { get; set; }
 
+	public int ModMaxVerticalSpeedDown { get; set; }
 }
 
 public class EntityCommandWallJump : EntityCommand<IEntityWallJumpable>
@@ -92,19 +93,23 @@ public class EntityCommandWallJump : EntityCommand<IEntityWallJumpable>
 
 			if (Entity.IsFalling())
 			{
-				var velocity = Entity.Velocity;
-				velocity.y = 1;
+				Entity.ModMaxVerticalSpeedDown = 20;
 
 				// fast fall
 				if (Entity is Player player)
 					if (player.PlayerInput.IsDown)
-						velocity.y += 200;
+						Entity.ModMaxVerticalSpeedDown = 220;
 
-				Entity.Velocity = velocity;
+				if (velocity.y != Entity.ModMaxVerticalSpeedDown)
+				{
+					velocity = velocity.MoveToward(new Vector2(velocity.x, Entity.ModMaxVerticalSpeedDown), 2000 * delta);
+				}
 			}
+			Entity.Velocity = velocity;
+		}
 
 		wasSliding = isSliding;
-		}
+	}
 
 	/// <summary>
 	/// Checks if the Entity should be sliding

--- a/Scripts/Entities/Commands/EntityCommandWallJump.cs
+++ b/Scripts/Entities/Commands/EntityCommandWallJump.cs
@@ -23,11 +23,11 @@ public interface IEntityWallJumpable : IEntityMoveable
 	// Vertical wall jump force
 	public int JumpForceWallVert { get; set; }
 
-	public int PreviousWallOnJump { get; set; }
 }
 
 public class EntityCommandWallJump : EntityCommand<IEntityWallJumpable>
 {
+	private int PreviousWallOnJump { get; set; }
 	public EntityCommandWallJump(IEntityWallJumpable entity) : base(entity) { }
 
 	public override void Start()
@@ -35,7 +35,7 @@ public class EntityCommandWallJump : EntityCommand<IEntityWallJumpable>
 		if (Entity.InWallJumpArea)
 		{
 			// If the entity is on a wall, prevent entity from wall jumping on the same wall twice
-			if (Entity.WallDir != 0 && Entity.PreviousWallOnJump != Entity.WallDir)
+			if (Entity.WallDir != 0 && PreviousWallOnJump != Entity.WallDir)
 			{
 				// wall jump
 				GameManager.EventsPlayer.Notify(EventPlayer.OnJump);
@@ -47,7 +47,7 @@ public class EntityCommandWallJump : EntityCommand<IEntityWallJumpable>
 				velocity.y -= Entity.JumpForceWallVert;
 				Entity.Velocity = velocity;
 
-				Entity.PreviousWallOnJump = Entity.WallDir;
+				PreviousWallOnJump = Entity.WallDir;
 			}
 		}
 		else
@@ -56,6 +56,11 @@ public class EntityCommandWallJump : EntityCommand<IEntityWallJumpable>
 
 	public override void Update(float delta)
 	{
+		if (Entity.IsOnGround())
+		{
+			PreviousWallOnJump = 0;
+		}
+
 		Entity.WallDir = UpdateWallDirection();
 
 		if (Entity.WallDir != 0 && Entity.InWallJumpArea)

--- a/Scripts/Entities/Commands/EntityCommandWallJump.cs
+++ b/Scripts/Entities/Commands/EntityCommandWallJump.cs
@@ -39,7 +39,7 @@ public class EntityCommandWallJump : EntityCommand<IEntityWallJumpable>
 		if (Entity.InWallJumpArea)
 		{
 			// If the entity is on a wall, prevent entity from wall jumping on the same wall twice
-			if (Entity.WallDir != 0 && PreviousWallOnJump != Entity.WallDir)
+			if (Entity.WallDir != 0)
 			{
 				// wall jump
 				GameManager.EventsPlayer.Notify(EventPlayer.OnJump);
@@ -49,6 +49,10 @@ public class EntityCommandWallJump : EntityCommand<IEntityWallJumpable>
 				var velocity = Entity.Velocity;
 				velocity.x += -Entity.JumpForceWallHorz * Entity.WallDir;
 				velocity.y = -Entity.JumpForceWallVert;
+				if (PreviousWallOnJump == Entity.WallDir)
+				{
+					velocity.y /= 2;
+				}
 				Entity.Velocity = velocity;
 
 				PreviousWallOnJump = Entity.WallDir;

--- a/Scripts/Entities/Entity.cs
+++ b/Scripts/Entities/Entity.cs
@@ -14,9 +14,9 @@ public partial class Entity : CharacterBody2D
 	public bool            GravityEnabled          { get; set; } = true;
 	public List<RayCast2D> RayCast2DGroundChecks   { get;      } = new();
 	public bool            HaltLogic               { get; set; }
-	public virtual int     ModMaxVerticalSpeedDown { get; set; } = 1200;
+	public virtual int     ModGravityMaxSpeed { get; set; } = 1200;
 
-	protected int maxVerticalSpeedDown = 1200;
+	protected int gravityMaxSpeed = 1200;
 
 	public override void _Ready()
 	{
@@ -60,7 +60,7 @@ public partial class Entity : CharacterBody2D
 		if (HaltLogic)
 			return;
 
-		ModMaxVerticalSpeedDown = maxVerticalSpeedDown;
+		ModGravityMaxSpeed = gravityMaxSpeed;
 		Delta = (float)delta;
 		Animations[CurrentAnimation].UpdateState();
 		Animations[CurrentAnimation].HandleStateTransitions();
@@ -69,7 +69,7 @@ public partial class Entity : CharacterBody2D
 
 		// gravity
 		if (GravityEnabled)
-			Velocity = Velocity.MoveToward(new Vector2(0, ModMaxVerticalSpeedDown), Gravity * Delta);
+			Velocity = Velocity.MoveToward(new Vector2(0, ModGravityMaxSpeed), Gravity * Delta);
 
 		if (IsOnGround())
 			UpdateGround();

--- a/Scripts/Entities/Entity.cs
+++ b/Scripts/Entities/Entity.cs
@@ -7,13 +7,16 @@ public partial class Entity : CharacterBody2D
 
 	public EntityAnimationType CurrentAnimation { get; set; } = EntityAnimationType.None;
 
-	public float           Delta                 { get; protected set; }
-	public Vector2         MoveDir               { get; protected set; }
-	public GTimers         Timers                { get; set; }
-	public virtual int     Gravity               { get; set; } = 1200;
-	public bool            GravityEnabled        { get; set; } = true;
-	public List<RayCast2D> RayCast2DGroundChecks { get;      } = new();
-	public bool            HaltLogic             { get; set; }
+	public float           Delta                   { get; protected set; }
+	public Vector2         MoveDir                 { get; protected set; }
+	public GTimers         Timers                  { get; set; }
+	public virtual int     Gravity                 { get; set; } = 1200;
+	public bool            GravityEnabled          { get; set; } = true;
+	public List<RayCast2D> RayCast2DGroundChecks   { get;      } = new();
+	public bool            HaltLogic               { get; set; }
+	public virtual int     ModMaxVerticalSpeedDown { get; set; } = 1200;
+
+	protected int maxVerticalSpeedDown = 1200;
 
 	public override void _Ready()
 	{
@@ -57,6 +60,7 @@ public partial class Entity : CharacterBody2D
 		if (HaltLogic)
 			return;
 
+		ModMaxVerticalSpeedDown = maxVerticalSpeedDown;
 		Delta = (float)delta;
 		Animations[CurrentAnimation].UpdateState();
 		Animations[CurrentAnimation].HandleStateTransitions();
@@ -65,7 +69,7 @@ public partial class Entity : CharacterBody2D
 
 		// gravity
 		if (GravityEnabled)
-			Velocity = Velocity + new Vector2(0, Gravity * Delta);
+			Velocity = Velocity.MoveToward(new Vector2(0, ModMaxVerticalSpeedDown), Gravity * Delta);
 
 		if (IsOnGround())
 			UpdateGround();

--- a/Scripts/Entities/Player/MovementUtils.cs
+++ b/Scripts/Entities/Player/MovementUtils.cs
@@ -57,23 +57,15 @@ public class MovementUtils
 		var y = 0;
 
 		if (vector.x > 0)
-		{
 			x = 1;
-		}
 		else if (vector.x < 0)
-		{
 			x = -1;
-		}
 
 		if (vector.y > 0)
-		{
 			y = 1;
-		}
-
 		if (vector.y < 0)
-		{
 			y = -1;
-		}
+
 		return new Vector2(x, y);
 	}
 }

--- a/Scripts/Entities/Player/MovementUtils.cs
+++ b/Scripts/Entities/Player/MovementUtils.cs
@@ -46,4 +46,34 @@ public class MovementUtils
 	{
 		return vector.y > 0;
 	}
+
+	/// <summary>
+	/// Convert a vector into a direction vector (e.g. 1 if movement towards left)
+	/// </summary>
+	/// <returns>Vector where x,y are 1, 0, or -1</returns>
+	public static Vector2 GetDirection(Vector2 vector)
+	{
+		var x = 0;
+		var y = 0;
+
+		if (vector.x > 0)
+		{
+			x = 1;
+		}
+		else if (vector.x < 0)
+		{
+			x = -1;
+		}
+
+		if (vector.y > 0)
+		{
+			y = 1;
+		}
+
+		if (vector.y < 0)
+		{
+			y = -1;
+		}
+		return new Vector2(x, y);
+	}
 }

--- a/Scripts/Entities/Player/Player.cs
+++ b/Scripts/Entities/Player/Player.cs
@@ -22,7 +22,6 @@ public partial class Player : Entity, IPlayerAnimations, IPlayerCommands
 	public List<RayCast2D> RayCast2DWallChecksRight { get; } = new();
 	public int             JumpForceWallHorz        { get; set; } = 800;
 	public int             JumpForceWallVert        { get; set; } = 500;
-	public int             PreviousWallOnJump       { get; set; }
 
 	// IEntityJumpable
 	public int  JumpCount      { get; set; }
@@ -149,8 +148,6 @@ public partial class Player : Entity, IPlayerAnimations, IPlayerCommands
 
 	public override void UpdateGround()
 	{
-		PreviousWallOnJump = 0; // reset to 0 so player can touch same wall again
-
 		Velocity = Velocity + new Vector2(MoveDir.x * GroundAcceleration, 0);
 
 		if (PlayerInput.IsSprint)

--- a/Scripts/Utils/Extensions/ExtensionsCollections.cs
+++ b/Scripts/Utils/Extensions/ExtensionsCollections.cs
@@ -9,64 +9,63 @@ public static class CollectionExtensions
 	/// <summary>
 	/// Prints a collection in a readable format
 	/// </summary>
-    public static string Print<T>(this IEnumerable<T> value, bool newLine = true) =>
-        value != null ? string.Join(newLine ? "\n" : ", ", value) : null;
+	public static string Print<T>(this IEnumerable<T> value, bool newLine = true) =>
+		value != null ? string.Join(newLine ? "\n" : ", ", value) : null;
 
 	/// <summary>
 	/// Prints the entire object in a readable format (supports Godot properties)
 	/// If you should ever run into a problem, see the IgnorePropsResolver class to ignore more
 	/// properties.
 	/// </summary>
-    public static string PrintFull(this object v) =>
-        JsonConvert.SerializeObject(v, Formatting.Indented, new JsonSerializerSettings
-        {
-            ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-            ContractResolver = new IgnorePropsResolver() // ignore all Godot props
-        });
-
+	public static string PrintFull(this object v) =>
+		JsonConvert.SerializeObject(v, Formatting.Indented, new JsonSerializerSettings
+		{
+			ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+			ContractResolver = new IgnorePropsResolver() // ignore all Godot props
+		});
 
 	/// <summary>
 	/// A convience method for a foreach loop at the the sacrafice of debugging support
 	/// </summary>
-    public static void ForEach<T>(this IEnumerable<T> value, Action<T> action)
-    {
-        foreach (var element in value)
-            action(element);
-    }
+	public static void ForEach<T>(this IEnumerable<T> value, Action<T> action)
+	{
+		foreach (var element in value)
+			action(element);
+	}
 
 	/// <summary>
 	/// Returns true if a dictionary has a duplicate key and warns the coder
 	/// </summary>
-    public static bool Duplicate<TKey, TValue>(this IDictionary<TKey, TValue> dict, TKey key,
-        [CallerLineNumber] int lineNumber = 0,
-        [CallerMemberName] string caller = null,
-        [CallerFilePath] string path = null)
-    {
-        if (!dict.ContainsKey(key))
-            return false;
+	public static bool Duplicate<TKey, TValue>(this IDictionary<TKey, TValue> dict, TKey key,
+		[CallerLineNumber] int lineNumber = 0,
+		[CallerMemberName] string caller = null,
+		[CallerFilePath] string path = null)
+	{
+		if (!dict.ContainsKey(key))
+			return false;
 
-        Logger.LogWarning($"'{caller}' tried to add duplicate key '{key}' to dictionary\n" +
-                            $"   at {path} line:{lineNumber}");
+		Logger.LogWarning($"'{caller}' tried to add duplicate key '{key}' to dictionary\n" +
+							$"   at {path} line:{lineNumber}");
 
-        return true;
-    }
+		return true;
+	}
 
 	/// <summary>
 	/// Returns true if a dictionary has a non-existent key and warns the coder
 	/// </summary>
-    public static bool DoesNotHave<TKey, TValue>(this IDictionary<TKey, TValue> dict, TKey key,
-        [CallerLineNumber] int lineNumber = 0,
-        [CallerMemberName] string caller = null,
-        [CallerFilePath] string path = null)
-    {
-        if (dict.ContainsKey(key))
-            return false;
+	public static bool DoesNotHave<TKey, TValue>(this IDictionary<TKey, TValue> dict, TKey key,
+		[CallerLineNumber] int lineNumber = 0,
+		[CallerMemberName] string caller = null,
+		[CallerFilePath] string path = null)
+	{
+		if (dict.ContainsKey(key))
+			return false;
 
-        Logger.LogWarning($"'{caller}' tried to access non-existent key '{key}' from dictionary\n" +
-                            $"   at {path} line:{lineNumber}");
+		Logger.LogWarning($"'{caller}' tried to access non-existent key '{key}' from dictionary\n" +
+							$"   at {path} line:{lineNumber}");
 
-        return true;
-    }
+		return true;
+	}
 
 	/// <summary>
 	/// Checks if any raycasts in a collection is colliding
@@ -83,33 +82,47 @@ public static class CollectionExtensions
 	}
 
 	/// <summary>
+	/// Returns the first raycasts in a collection which is colliding
+	/// </summary>
+	/// <param name="raycasts">Collection of raycasts to check</param>
+	/// <returns>Raycast which is colliding, else default</returns>
+	public static RayCast2D GetAnyRayCastCollider(List<RayCast2D> raycasts)
+	{
+		foreach (var raycast in raycasts)
+			if (raycast.IsColliding())
+				return raycast;
+
+		return default;
+	}
+
+	/// <summary>
 	/// Used when doing JsonConvert.SerializeObject to ignore Godot properties
 	/// as these are massive.
 	/// </summary>
-    private class IgnorePropsResolver : DefaultContractResolver
-    {
-        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
-        {
-            var prop = base.CreateProperty(member, memberSerialization);
+	private class IgnorePropsResolver : DefaultContractResolver
+	{
+		protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+		{
+			var prop = base.CreateProperty(member, memberSerialization);
 
 			// Ignored properties (prevents crashes)
-            var ignoredProps = new Type[]
-            {
-                typeof(Godot.Object),
-                typeof(Node),
-                typeof(NodePath)
-            };
+			var ignoredProps = new Type[]
+			{
+				typeof(Godot.Object),
+				typeof(Node),
+				typeof(NodePath)
+			};
 
-            foreach (var ignoredProp in ignoredProps) 
-            {
-                if (ignoredProp.GetProperties().Contains(member))
-                    prop.Ignored = true;
+			foreach (var ignoredProp in ignoredProps)
+			{
+				if (ignoredProp.GetProperties().Contains(member))
+					prop.Ignored = true;
 
-                if (prop.PropertyType == ignoredProp || prop.PropertyType.IsSubclassOf(ignoredProp))
-                    prop.Ignored = true;
-            }
+				if (prop.PropertyType == ignoredProp || prop.PropertyType.IsSubclassOf(ignoredProp))
+					prop.Ignored = true;
+			}
 
-            return prop;
-        }
-    }
+			return prop;
+		}
+	}
 }


### PR DESCRIPTION
Summary: Let's try making wall jumping feel _a little_ better.

Changes:

1. Animation - Animation was kinda strange for wall jumping esp. with dashes. Let's go to idle state more often to find the proper state to be in.

old: 
![animationsold](https://user-images.githubusercontent.com/1704165/197663483-6f8b0fb2-f474-4cfd-b1c8-e96cca2cdeb9.gif)

new:
![animationsnew](https://user-images.githubusercontent.com/1704165/197663497-6973e8d5-e915-43ac-aa96-dab1bb3d0f39.gif)


2. Jump prevention - It feels bad to be unable to jump. Instead let's heavily impact the jump amount for consecutive jumps.

![wallJumping](https://user-images.githubusercontent.com/1704165/197663275-76d25bd7-0d5b-4987-9c6f-fd35b796c046.gif)

3. Wall latching - before we could be on the wall but our sprite would be slightly off of it, let's instead latch to the wall when we are close enough

<img width="65" alt="image" src="https://user-images.githubusercontent.com/1704165/197663063-4372caf2-e536-484f-95b6-ff561ab3b0f1.png">

4. Physics jumping - Physics jumping is inconsistent, but kinda neat. Personally, I found it annoying.

Old:
![physicsJumpOld](https://user-images.githubusercontent.com/1704165/197664132-bc94df60-f70f-484e-a8e4-55c49e42ccc8.gif)

New:
![physicsJumpNew](https://user-images.githubusercontent.com/1704165/197664122-3e14f546-2842-4529-a835-374e0dc9b0be.gif)
