### PR TITLE
Cleanup interfaces

### DIFF
--- a/Scripts/Entities/Animations/EntityAnimation.cs
+++ b/Scripts/Entities/Animations/EntityAnimation.cs
@@ -13,10 +13,10 @@ public enum EntityAnimationType
 
 public interface IEntityAnimation : IEntityBase
 {
-	public Dictionary<EntityAnimationType, EntityAnimation> Animations   { get; set; }
-	public Dictionary<EntityCommandType, EntityCommand>     Commands     { get; set; }
+	public Dictionary<EntityAnimationType, EntityAnimation> Animations   { get; }
+	public Dictionary<EntityCommandType, EntityCommand>     Commands     { get; }
 	public EntityAnimationType                              CurrentAnimation   { get; set; }
-	public AnimatedSprite2D                                 AnimatedSprite     { get; set; }
+	public AnimatedSprite2D                                 AnimatedSprite     { get; }
 }
 
 public abstract class EntityAnimation<T> : EntityAnimation where T : IEntityAnimation
@@ -52,11 +52,27 @@ public abstract class EntityAnimation
 	public EntityAnimation()
 	{ }
 
-	public abstract void UpdateState();
+	/// <summary>
+	/// Update the current animation
+	/// </summary>
+	public virtual void UpdateState()
+	{ }
 
-	public abstract void HandleStateTransitions();
+	/// <summary>
+	/// Potentially transition to a new state
+	/// </summary>
+	public virtual void HandleStateTransitions()
+	{ }
 
-	public abstract void EnterState();
+	/// <summary>
+	/// Setup and start the animation
+	/// </summary>
+	public virtual void EnterState()
+	{ }
 
-	public abstract void ExitState();
+	/// <summary>
+	/// Cleanly exit the animation state
+	/// </summary>
+	public virtual void ExitState()
+	{ }
 }

--- a/Scripts/Entities/Animations/EntityAnimationDash.cs
+++ b/Scripts/Entities/Animations/EntityAnimationDash.cs
@@ -10,11 +10,6 @@ public class EntityAnimationDash : EntityAnimation<IEntityAnimationDash>
 	{
 	}
 
-	public override void EnterState()
-	{
-		// no animation for dash exists at this time
-	}
-
 	public override void UpdateState()
 	{
 		FlipSpriteOnDirection();
@@ -46,9 +41,5 @@ public class EntityAnimationDash : EntityAnimation<IEntityAnimationDash>
 				// entity is touching the ground
 				SwitchState(EntityAnimationType.Idle);
 			}
-	}
-
-	public override void ExitState()
-	{
 	}
 }

--- a/Scripts/Entities/Animations/EntityAnimationIdle.cs
+++ b/Scripts/Entities/Animations/EntityAnimationIdle.cs
@@ -9,11 +9,9 @@ public class EntityAnimationIdle : EntityAnimation<IEntityAnimation>
 	public override void EnterState()
 	{
 		Entity.AnimatedSprite.Play("idle");
+		// Idle animation should only occur if nothing else interesting is happening
+		// Transition immediately to see if there is a better animation to be in
 		HandleStateTransitions();
-	}
-
-	public override void UpdateState()
-	{
 	}
 
 	public override void HandleStateTransitions()
@@ -41,9 +39,5 @@ public class EntityAnimationIdle : EntityAnimation<IEntityAnimation>
 			else if (player.Velocity.y != 0)
 				SwitchState(EntityAnimationType.JumpStart);
 		}
-	}
-
-	public override void ExitState()
-	{
 	}
 }

--- a/Scripts/Entities/Animations/EntityAnimationJumpFall.cs
+++ b/Scripts/Entities/Animations/EntityAnimationJumpFall.cs
@@ -37,11 +37,6 @@ public class EntityAnimationJumpFall : EntityAnimation<IEntityAnimation>
 				SwitchState(EntityAnimationType.Dash);
 			else if (!player.IsFalling() && player.Velocity.y != 0)
 				SwitchState(EntityAnimationType.JumpStart);
-
 		}
-	}
-
-	public override void ExitState()
-	{
 	}
 }

--- a/Scripts/Entities/Animations/EntityAnimationJumpStart.cs
+++ b/Scripts/Entities/Animations/EntityAnimationJumpStart.cs
@@ -28,20 +28,13 @@ public class EntityAnimationJumpStart : EntityAnimation<IEntityAnimation>
 		if (Entity is Player player)
 		{
 			if (player.IsFalling())
-
 				SwitchState(EntityAnimationType.JumpFall);
 
 			else if (player.PlayerInput.IsDash)
-
 				SwitchState(EntityAnimationType.Dash);
 
 			else if (player.IsOnGround() && Entity.MoveDir == Vector2.Zero && !TimerDontCheckOnGround.IsActive())
-
 				SwitchState(EntityAnimationType.Idle);
 		}
-	}
-
-	public override void ExitState()
-	{
 	}
 }

--- a/Scripts/Entities/Animations/EntityAnimationNone.cs
+++ b/Scripts/Entities/Animations/EntityAnimationNone.cs
@@ -1,19 +1,5 @@
 ﻿namespace Sankari;
+
 public class EntityAnimationNone : EntityAnimation
 {
-	public override void EnterState()
-	{
-	}
-
-	public override void ExitState()
-	{
-	}
-
-	public override void HandleStateTransitions()
-	{
-	}
-
-	public override void UpdateState()
-	{
-	}
 }

--- a/Scripts/Entities/Animations/EntityAnimationWalking.cs
+++ b/Scripts/Entities/Animations/EntityAnimationWalking.cs
@@ -26,24 +26,16 @@ public class EntityAnimationWalking : EntityAnimation<IEntityAnimation>
 		if (Entity is Player player)
 		{
 			if (player.PlayerInput.IsJump)
-
 				SwitchState(EntityAnimationType.JumpStart);
 
 			else if (player.PlayerInput.IsDash)
-
 				SwitchState(EntityAnimationType.Dash);
 
 			else if (player.PlayerInput.IsSprint)
-
 				SwitchState(EntityAnimationType.Running);
 
 			else if (player.MoveDir == Vector2.Zero || player.Velocity.y != 0)
-
 				SwitchState(EntityAnimationType.Idle);
 		}
-	}
-
-	public override void ExitState()
-	{
 	}
 }

--- a/Scripts/Entities/Commands/EntityCommandDash.cs
+++ b/Scripts/Entities/Commands/EntityCommandDash.cs
@@ -7,18 +7,32 @@ public interface IEntityDash : IEntityMoveable
 
 public class EntityCommandDash : EntityCommand<IEntityDash>
 {
-	public Vector2 DashDir           { get; set; }
+	#region Configuration
+	// Max number of allowed dashes before needing to be reset
 	public int     MaxDashes         { get; set; } = 1;
-	public int     DashCount         { get; set; }
-	public bool    HorizontalDash    { get; set; }
-	public bool    DashReady         { get; set; } = true;
+
+	// How long before dashing is available again
 	public int     DashCooldown      { get; set; }	= 1400;
+
+	// How long the dash lasts for
 	public int     DashDuration      { get; set; }	= 200;
-	public GTimer  TimerDashCooldown { get; set; }
-	public GTimer  TimerDashDuration { get; set; }
-	public bool CurrentlyDashing { get; set; } = false;
+
+	// Vertical dash speed
+	public int SpeedDashVertical     { get; set; } = 400;
+
+	// Horizontal dash speed
+	public int SpeedDashHorizontal   { get; set; } = 600;
+	#endregion
+
+	public bool CurrentlyDashing { get; protected set; } = false;
 
 	public event EventHandler DashDurationDone;
+	private bool    DashReady         { get; set; } = true;
+	private int     DashCount         { get; set; }
+	private Vector2 DashDir           { get; set; }
+	private bool    HorizontalDash    { get; set; }
+	private GTimer  TimerDashCooldown { get; set; }
+	private GTimer  TimerDashDuration { get; set; }
 
 	public EntityCommandDash(IEntityDash entity) : base(entity) { }
 
@@ -67,9 +81,6 @@ public class EntityCommandDash : EntityCommand<IEntityDash>
 			sprite.FlipH = Entity.AnimatedSprite.FlipH;
 			//sprite.FlipH = wallDir == 1 ? true : false; // cant remember why I commented this out
 			Entity.Tree.AddChild(sprite);
-
-			var SpeedDashVertical = 400;
-			var SpeedDashHorizontal = 600;
 
 			var dashSpeed = SpeedDashVertical;
 

--- a/Scripts/Entities/Commands/EntityCommandDash.cs
+++ b/Scripts/Entities/Commands/EntityCommandDash.cs
@@ -2,22 +2,21 @@
 
 public interface IEntityDash : IEntityMoveable
 {
-	public int MaxDashes           { get; set; }
-	public int DashCooldown        { get; set; }
-	public int DashDuration        { get; set; }
-	public int SpeedDashVertical   { get; set; }
-	public int SpeedDashHorizontal { get; set; }
+
 }
 
 public class EntityCommandDash : EntityCommand<IEntityDash>
 {
 	public Vector2 DashDir           { get; set; }
+	public int     MaxDashes         { get; set; } = 1;
 	public int     DashCount         { get; set; }
 	public bool    HorizontalDash    { get; set; }
 	public bool    DashReady         { get; set; } = true;
+	public int     DashCooldown      { get; set; }	= 1400;
+	public int     DashDuration      { get; set; }	= 200;
 	public GTimer  TimerDashCooldown { get; set; }
 	public GTimer  TimerDashDuration { get; set; }
-	public bool    CurrentlyDashing  { get; set; } = false;
+	public bool CurrentlyDashing { get; set; } = false;
 
 	public event EventHandler DashDurationDone;
 
@@ -25,13 +24,13 @@ public class EntityCommandDash : EntityCommand<IEntityDash>
 
 	public override void Initialize()
 	{
-		TimerDashCooldown = Entity.Timers.CreateTimer(new Callable(OnDashReady), Entity.DashCooldown, false, false);
-		TimerDashDuration = Entity.Timers.CreateTimer(new Callable(OnDashDurationDone), Entity.DashDuration, false, false);
+		TimerDashCooldown = Entity.Timers.CreateTimer(new Callable(OnDashReady), DashCooldown, false, false);
+		TimerDashDuration = Entity.Timers.CreateTimer(new Callable(OnDashDurationDone), DashDuration, false, false);
 	}
 
 	public override void Start()
 	{
-		if (DashReady && !CurrentlyDashing && DashCount != Entity.MaxDashes && !Entity.IsOnGround())
+		if (DashReady && !CurrentlyDashing && DashCount != MaxDashes && !Entity.IsOnGround())
 		{
 			DashDir = GetDashDirection(Entity.MoveDir);
 
@@ -69,10 +68,13 @@ public class EntityCommandDash : EntityCommand<IEntityDash>
 			//sprite.FlipH = wallDir == 1 ? true : false; // cant remember why I commented this out
 			Entity.Tree.AddChild(sprite);
 
-			var dashSpeed = Entity.SpeedDashVertical;
+			var SpeedDashVertical = 400;
+			var SpeedDashHorizontal = 600;
+
+			var dashSpeed = SpeedDashVertical;
 
 			if (HorizontalDash)
-				dashSpeed = Entity.SpeedDashHorizontal;
+				dashSpeed = SpeedDashHorizontal;
 
 			Entity.Velocity = DashDir * dashSpeed;
 		}

--- a/Scripts/Entities/Commands/EntityCommandGroundJump.cs
+++ b/Scripts/Entities/Commands/EntityCommandGroundJump.cs
@@ -2,24 +2,50 @@
 
 public interface IEntityJumpable : IEntityMovement
 {
-	public int JumpCount { get; set; }
 }
 
-public interface IEntityGroundJumpable : IEntityJumpable 
+public interface IEntityGroundJumpable : IEntityJumpable
 {
-	public int JumpForce { get; set; }	
+	bool IsFalling();
 }
 
 public class EntityCommandGroundJump : EntityCommand<IEntityGroundJumpable>
 {
+	#region Configuration
+
+	// Force applies when jumping
+	public int JumpForce { get; set; } = 600;
+
+	// Max number of Jumps
+	public int MaxJumps { get; set; } = 1;
+
+	// Allow mid air jumping
+	public bool AllowAirJumps { get; set; } = false;
+
+	#endregion
+
+	private int JumpCount { get; set; }
+
 	public EntityCommandGroundJump(IEntityGroundJumpable entity) : base(entity) { }
+
+	public override void Update(float delta)
+	{
+		// Check if Entity in on ground and not current moving away from it
+		if (Entity.IsOnGround() && Entity.Velocity.y >=0)
+		{
+			JumpCount = 0;
+		}
+	}
 
 	public override void Start()
 	{
-		GameManager.EventsPlayer.Notify(EventPlayer.OnJump);
+		if (JumpCount < MaxJumps && (Entity.IsOnGround() || AllowAirJumps))
+		{
+			GameManager.EventsPlayer.Notify(EventPlayer.OnJump);
 
-		Entity.JumpCount++;
-		//Velocity = new Vector2(Velocity.x, 0); // reset velocity before jump (is this really needed?)
-		Entity.Velocity = Entity.Velocity - new Vector2(0, Entity.JumpForce);
+			JumpCount++;
+			//Velocity = new Vector2(Velocity.x, 0); // reset velocity before jump (is this really needed?)
+			Entity.Velocity = Entity.Velocity - new Vector2(0, JumpForce);
+		}
 	}
 }

--- a/Scripts/Entities/Commands/EntityCommandMovement.cs
+++ b/Scripts/Entities/Commands/EntityCommandMovement.cs
@@ -4,44 +4,46 @@ public interface IEntityMovement : IEntityMoveable, IEntityDash
 {
 	// Ground acceleration
 	public int GroundAcceleration { get; set; }
-	public int MaxSpeedWalk     { get; set; }
-	public int MaxSpeedSprint   { get; set; }
-	public int MaxSpeedAir      { get; set; }
-	public int AirAcceleration  { get; set; }
-	public int DampeningAir     { get; set; }
-	public int DampeningGround  { get; set; }
+
 }
 
 public class EntityCommandMovement : EntityCommand<IEntityMovement>
 {
+	public int MaxSpeedWalk     { get; set; } = 350;
+	public int MaxSpeedSprint   { get; set; } = 500;
+	public int MaxSpeedAir      { get; set; } = 350;
+	public int AirAcceleration  { get; set; } = 30;
+	public int DampeningAir     { get; set; } = 10;
+	public int DampeningGround  { get; set; } = 25;
+
 	public EntityCommandMovement(IEntityMovement entity) : base(entity) { }
 
 	public override void Initialize()
 	{
 		// if these are equal to each other then the player movement will not work as expected
-		if (Entity.GroundAcceleration == Entity.DampeningGround)
-			Entity.DampeningGround -= 1;
+		if (Entity.GroundAcceleration == DampeningGround)
+			DampeningGround -= 1;
 	}
 
 	public override void UpdateGroundWalking(float delta)
 	{
 		var velocity = Entity.Velocity;
-		velocity.x = ClampAndDampen(velocity.x, Entity.DampeningGround, Entity.MaxSpeedWalk);
+		velocity.x = ClampAndDampen(velocity.x, DampeningGround, MaxSpeedWalk);
 		Entity.Velocity = velocity;
 	}
 
 	public override void UpdateGroundSprinting(float delta)
 	{
 		var velocity = Entity.Velocity;
-		velocity.x = ClampAndDampen(velocity.x, Entity.DampeningGround, Entity.MaxSpeedSprint);
+		velocity.x = ClampAndDampen(velocity.x, DampeningGround, MaxSpeedSprint);
 		Entity.Velocity = velocity;
 	}
 
 	public override void UpdateAir(float delta)
 	{
 		var velocity = Entity.Velocity;
-		velocity.x += Entity.MoveDir.x * Entity.AirAcceleration;
-		velocity.x = ClampAndDampen(velocity.x, Entity.DampeningAir, Entity.MaxSpeedAir);
+		velocity.x += Entity.MoveDir.x * AirAcceleration;
+		velocity.x = ClampAndDampen(velocity.x, DampeningAir, MaxSpeedAir);
 		Entity.Velocity = velocity;
 	}
 

--- a/Scripts/Entities/Commands/EntityCommandMovement.cs
+++ b/Scripts/Entities/Commands/EntityCommandMovement.cs
@@ -9,13 +9,14 @@ public interface IEntityMovement : IEntityMoveable, IEntityDash
 
 public class EntityCommandMovement : EntityCommand<IEntityMovement>
 {
+	#region Configuration
 	public int MaxSpeedWalk     { get; set; } = 350;
 	public int MaxSpeedSprint   { get; set; } = 500;
 	public int MaxSpeedAir      { get; set; } = 350;
 	public int AirAcceleration  { get; set; } = 30;
 	public int DampeningAir     { get; set; } = 10;
 	public int DampeningGround  { get; set; } = 25;
-
+	#endregion
 	public EntityCommandMovement(IEntityMovement entity) : base(entity) { }
 
 	public override void Initialize()

--- a/Scripts/Entities/Commands/EntityCommandWallJump.cs
+++ b/Scripts/Entities/Commands/EntityCommandWallJump.cs
@@ -14,23 +14,31 @@ public interface IEntityWallJumpable : IEntityMoveable
 	// Wall direction
 	public int WallDir { get; set; }
 
-	// Is the entity falling?
-	public bool IsFalling();
-
-	// Horizontal wall jump force
-	public int JumpForceWallHorz { get; set; }
-
-	// Vertical wall jump force
-	public int JumpForceWallVert { get; set; }
-
 	// Max speed due to gravity
 	public int ModGravityMaxSpeed { get; set; }
+
+	// Is the entity falling?
+	public bool IsFalling();
 }
 
 public class EntityCommandWallJump : EntityCommand<IEntityWallJumpable>
 {
-	public int MaxGravitySpeedSliding {get; set;} = 20; 
-	public int MaxGravitySpeedSlidingFast {get; set;} = 220; 
+	#region Configuration
+
+	// Horizontal wall jump force
+	public int JumpForceWallHorz { get; set; } = 800;
+
+	// Vertical wall jump force
+	public int JumpForceWallVert { get; set; } = 500;
+
+	// Sliding force downwards
+	public int MaxGravitySpeedSliding { get; set; } = 20;
+
+	// Fast sliding force downwards
+	public int MaxGravitySpeedSlidingFast { get; set; } = 220;
+
+	#endregion
+
 	private int PreviousWallOnJump { get; set; }
 	private bool wasSliding = false;
 	private float previousXDir = 0;
@@ -50,8 +58,8 @@ public class EntityCommandWallJump : EntityCommand<IEntityWallJumpable>
 				Entity.AnimatedSprite.FlipH = Entity.WallDir == 1; // flip sprite on wall jump
 
 				var velocity = Entity.Velocity;
-				velocity.x += -Entity.JumpForceWallHorz * Entity.WallDir;
-				velocity.y = -Entity.JumpForceWallVert;
+				velocity.x += -JumpForceWallHorz * Entity.WallDir;
+				velocity.y = -JumpForceWallVert;
 				if (PreviousWallOnJump == Entity.WallDir)
 				{
 					velocity.y /= 2;

--- a/Scripts/Entities/Commands/EntityCommandWallJump.cs
+++ b/Scripts/Entities/Commands/EntityCommandWallJump.cs
@@ -29,10 +29,9 @@ public interface IEntityWallJumpable : IEntityMoveable
 
 public class EntityCommandWallJump : EntityCommand<IEntityWallJumpable>
 {
-	public int MaxGravitySpeedSliding { get; set; } = 20; 
-	public int MaxGravitySpeedSlidingFast { get; set; } = 220; 
+	public int MaxGravitySpeedSliding {get; set;} = 20; 
+	public int MaxGravitySpeedSlidingFast {get; set;} = 220; 
 	private int PreviousWallOnJump { get; set; }
-
 	private bool wasSliding = false;
 	private float previousXDir = 0;
 

--- a/Scripts/Entities/Enemy/BasicEnemy.cs
+++ b/Scripts/Entities/Enemy/BasicEnemy.cs
@@ -19,21 +19,6 @@ public partial class BasicEnemy : Entity, IEnemy, IEntity, IEntityMovement
 	public int GroundAcceleration { get; set; } = 50;
 	public Window Tree { get; set; }
 
-	// IEntityDash
-	public int MaxDashes { get; set; }
-	public int DashCooldown { get; set; }
-	public int DashDuration { get; set; }
-	public int SpeedDashVertical { get; set; }
-	public int SpeedDashHorizontal { get; set; }
-
-	// IEntityMovement
-	public int MaxSpeedWalk     { get; set; } = 350;
-	public int MaxSpeedSprint   { get; set; } = 500;
-	public int MaxSpeedAir      { get; set; } = 350;
-	public int AirAcceleration  { get; set; } = 30;
-	public int DampeningAir     { get; set; } = 10;
-	public int DampeningGround  { get; set; } = 25;
-
 	public override void _Ready()
 	{
 		AnimatedSprite = GetNode<AnimatedSprite2D>("AnimatedSprite2D");

--- a/Scripts/Entities/Entity.cs
+++ b/Scripts/Entities/Entity.cs
@@ -7,25 +7,14 @@ public partial class Entity : CharacterBody2D
 
 	public EntityAnimationType CurrentAnimation { get; set; } = EntityAnimationType.None;
 
-	public GTimer          TimerNetSend                       { get; set; }
-	public Node2D          ParentWallChecksLeft               { get; set; }
-	public Node2D          ParentWallChecksRight              { get; set; }
-	public Node2D          ParentGroundChecks                 { get; set; }
-	public LevelScene      LevelScene                         { get; set; }
-	public Vector2         PrevNetPos                         { get; set; }
-	public float           Delta                              { get; protected set; }
-	public Vector2         MoveDir                            { get; protected set; }
-	public GTimers         Timers                             { get; set; }
-	public virtual int     Gravity                            { get; set; } = 1200;
-	public bool            GravityEnabled                     { get; set; } = true;
-	public List<RayCast2D> RayCast2DGroundChecks              { get;      } = new();
-	public bool            HaltLogic                          { get; set; }
-	public virtual int     ModGravityMaxSpeed                 { get; set; } = 1200;
-	public int             MaxJumps                           { get; set; } = 1;
-	public int             HorizontalDeadZone                 { get; set; } = 25;
-	public GTween          DieTween                           { get; set; }
-	public bool            TouchedGround                      { get; set; }
-	public GTimer          DontCheckPlatformAfterDashDuration { get; set; }
+	public float           Delta                   { get; protected set; }
+	public Vector2         MoveDir                 { get; protected set; }
+	public GTimers         Timers                  { get; set; }
+	public virtual int     Gravity                 { get; set; } = 1200;
+	public bool            GravityEnabled          { get; set; } = true;
+	public List<RayCast2D> RayCast2DGroundChecks   { get;      } = new();
+	public bool            HaltLogic               { get; set; }
+	public virtual int     ModGravityMaxSpeed { get; set; } = 1200;
 
 	protected int gravityMaxSpeed = 1200;
 

--- a/Scripts/Entities/Entity.cs
+++ b/Scripts/Entities/Entity.cs
@@ -14,7 +14,11 @@ public partial class Entity : CharacterBody2D
 	public bool            GravityEnabled          { get; set; } = true;
 	public List<RayCast2D> RayCast2DGroundChecks   { get;      } = new();
 	public bool            HaltLogic               { get; set; }
-	public virtual int     ModGravityMaxSpeed { get; set; } = 1200;
+	public virtual int     ModGravityMaxSpeed      { get; set; } = 1200;
+	public Node2D          ParentWallChecksLeft    { get; set; }
+	public Node2D          ParentWallChecksRight   { get; set; }
+	public bool            TouchedGround           { get; set; }
+	public Node2D          ParentGroundChecks      { get; set; }
 
 	protected int gravityMaxSpeed = 1200;
 

--- a/Scripts/Entities/Player/Player.cs
+++ b/Scripts/Entities/Player/Player.cs
@@ -42,15 +42,11 @@ public partial class Player : Entity, IPlayerAnimations, IPlayerCommands
 	// Not in a interface
 	private int DamageTakenForce = 300;
 	public GTimer        TimerNetSend                       { get; set; }
-	public Node2D        ParentWallChecksLeft               { get; set; }
-	public Node2D        ParentWallChecksRight              { get; set; }
-	public Node2D        ParentGroundChecks                 { get; set; }
 	public LevelScene    LevelScene                         { get; set; }
 	public Vector2       PrevNetPos                         { get; set; }
 	public MovementInput PlayerInput                        { get; set; }
 	public int           HorizontalDeadZone                 { get; set; } = 25;
 	public GTween        DieTween                           { get; set; }
-	public bool          TouchedGround                      { get; set; }
 	public GTimer        DontCheckPlatformAfterDashDuration { get; set; }
 
 	public void PreInit(LevelScene levelScene) => LevelScene = levelScene;

--- a/Scripts/Entities/Player/Player.cs
+++ b/Scripts/Entities/Player/Player.cs
@@ -8,28 +8,24 @@ public interface IPlayerCommands : IEntityDash, IEntityWallJumpable, IEntityGrou
 
 public partial class Player : Entity, IPlayerAnimations, IPlayerCommands
 {
-	[Export] protected NodePath NodePathRayCast2DWallChecksLeft  { get; set; }
+	[Export] protected NodePath NodePathRayCast2DWallChecksLeft { get; set; }
 	[Export] protected NodePath NodePathRayCast2DWallChecksRight { get; set; }
-	[Export] protected NodePath NodePathRayCast2DGroundChecks    { get; set; }
+	[Export] protected NodePath NodePathRayCast2DGroundChecks { get; set; }
 
 	// Static
-	public static Vector2 RespawnPosition      { get; set; }
-	public static bool    HasTouchedCheckpoint { get; set; }
+	public static Vector2 RespawnPosition { get; set; }
 
+	public static bool HasTouchedCheckpoint { get; set; }
 
 	// IEntityWallJumpable
-	public List<RayCast2D> RayCast2DWallChecksLeft  { get; } = new();
+	public List<RayCast2D> RayCast2DWallChecksLeft { get; } = new();
+
 	public List<RayCast2D> RayCast2DWallChecksRight { get; } = new();
-	public int             JumpForceWallHorz        { get; set; } = 800;
-	public int             JumpForceWallVert        { get; set; } = 500;
 
 	// IEntityJumpable
-	public int  JumpCount      { get; set; }
 	public bool InWallJumpArea { get; set; }
-	public int  WallDir        { get; set; }
 
-	// IEntityGroundJumpable
-	public int JumpForce { get; set; } = 600;
+	public int WallDir { get; set; }
 
 	// IEntityMovement
 	public int GroundAcceleration { get; set; } = 50;
@@ -44,6 +40,7 @@ public partial class Player : Entity, IPlayerAnimations, IPlayerCommands
 	public AnimatedSprite2D AnimatedSprite { get; set; }
 
 	// Not in a interface
+	private int DamageTakenForce = 300;
 	public GTimer        TimerNetSend                       { get; set; }
 	public Node2D        ParentWallChecksLeft               { get; set; }
 	public Node2D        ParentWallChecksRight              { get; set; }
@@ -51,7 +48,6 @@ public partial class Player : Entity, IPlayerAnimations, IPlayerCommands
 	public LevelScene    LevelScene                         { get; set; }
 	public Vector2       PrevNetPos                         { get; set; }
 	public MovementInput PlayerInput                        { get; set; }
-	public int           MaxJumps                           { get; set; } = 1;
 	public int           HorizontalDeadZone                 { get; set; } = 25;
 	public GTween        DieTween                           { get; set; }
 	public bool          TouchedGround                      { get; set; }
@@ -104,7 +100,7 @@ public partial class Player : Entity, IPlayerAnimations, IPlayerCommands
 			return;
 
 		PlayerInput = MovementUtils.GetPlayerMovementInput(); // PlayerInput = ... needs to go before base._PhysicsProcess(delta)
-		
+
 		base._PhysicsProcess(delta);
 
 		UpdateMoveDirection(PlayerInput);
@@ -119,16 +115,9 @@ public partial class Player : Entity, IPlayerAnimations, IPlayerCommands
 			{
 				Commands[EntityCommandType.WallJump].Start();
 			}
-			else if (JumpCount < MaxJumps) 
+			else
 			{
-				if (IsOnGround()) // Ground jump
-				{
-					Commands[EntityCommandType.GroundJump].Start();
-				}
-				else // Mid air jump
-				{
-					// to be implemented as a permanent or temporary powerup
-				}
+				Commands[EntityCommandType.GroundJump].Start();
 			}
 		}
 
@@ -146,10 +135,6 @@ public partial class Player : Entity, IPlayerAnimations, IPlayerCommands
 			Commands.Values.ForEach(cmd => cmd.UpdateGroundSprinting(Delta));
 		else
 			Commands.Values.ForEach(cmd => cmd.UpdateGroundWalking(Delta));
-
-		// reset jump count whenever the player is falling
-		if (IsFalling())
-			JumpCount = 0;
 	}
 
 	public override void UpdateAir()
@@ -226,8 +211,8 @@ public partial class Player : Entity, IPlayerAnimations, IPlayerCommands
 			Vector2 velocity;
 			Commands[EntityCommandType.Dash].Stop();
 
-			velocity.y = -JumpForce * 0.5f; // make y and x jumps less aggressive
-			velocity.x = side * JumpForce * 0.5f;
+			velocity.y = -DamageTakenForce;
+			velocity.x = side * DamageTakenForce;
 			Velocity = velocity;
 		}
 	}

--- a/Scripts/Entities/Player/Player.cs
+++ b/Scripts/Entities/Player/Player.cs
@@ -16,6 +16,7 @@ public partial class Player : Entity, IPlayerAnimations, IPlayerCommands
 	public static Vector2 RespawnPosition      { get; set; }
 	public static bool    HasTouchedCheckpoint { get; set; }
 
+
 	// IEntityWallJumpable
 	public List<RayCast2D> RayCast2DWallChecksLeft  { get; } = new();
 	public List<RayCast2D> RayCast2DWallChecksRight { get; } = new();
@@ -32,29 +33,29 @@ public partial class Player : Entity, IPlayerAnimations, IPlayerCommands
 
 	// IEntityMovement
 	public int GroundAcceleration { get; set; } = 50;
-	public int MaxSpeedWalk       { get; set; } = 350;
-	public int MaxSpeedSprint     { get; set; } = 500;
-	public int MaxSpeedAir        { get; set; } = 350;
-	public int AirAcceleration    { get; set; } = 30;
-	public int DampeningAir       { get; set; } = 10;
-	public int DampeningGround    { get; set; } = 25;
 
 	// IEntityMoveable
 	public Window Tree { get; set; }
 
 	// IEntityDash
-	public int MaxDashes           { get; set; } = 1;
-	public int DashCooldown        { get; set; } = 1400;
-	public int DashDuration        { get; set; } = 200;
-	public int SpeedDashVertical   { get; set; } = 400;
-	public int SpeedDashHorizontal { get; set; } = 600;
+	public bool CurrentlyDashing { get; set; }
 
 	// IEntityAnimation
 	public AnimatedSprite2D AnimatedSprite { get; set; }
 
 	// Not in a interface
-	public bool CurrentlyDashing { get; set; }
-	public MovementInput PlayerInput { get; set; }
+	public GTimer        TimerNetSend                       { get; set; }
+	public Node2D        ParentWallChecksLeft               { get; set; }
+	public Node2D        ParentWallChecksRight              { get; set; }
+	public Node2D        ParentGroundChecks                 { get; set; }
+	public LevelScene    LevelScene                         { get; set; }
+	public Vector2       PrevNetPos                         { get; set; }
+	public MovementInput PlayerInput                        { get; set; }
+	public int           MaxJumps                           { get; set; } = 1;
+	public int           HorizontalDeadZone                 { get; set; } = 25;
+	public GTween        DieTween                           { get; set; }
+	public bool          TouchedGround                      { get; set; }
+	public GTimer        DontCheckPlatformAfterDashDuration { get; set; }
 
 	public void PreInit(LevelScene levelScene) => LevelScene = levelScene;
 


### PR DESCRIPTION
Reverted the changes due to interface moving and made them more standard.


Summary:
1. Animations - We were implementing Enter/Exit state even if we didn't need them
2. Commands - Moved properties that were more like "configurations" to the interface class. Should be more clear now how Commands-entity framework works
3. Moved Jump logic into Jump

Changes are a bit controversial.