### PR TITLE
Rough outline on how to prevent movement

### DIFF
--- a/Scripts/Entities/Commands/EntityCommandWallJump.cs
+++ b/Scripts/Entities/Commands/EntityCommandWallJump.cs
@@ -36,6 +36,7 @@ public class EntityCommandWallJump : EntityCommand<IEntityWallJumpable>
 
 	#endregion
 
+	public event EventHandler Jump;
 	private int previousWallOnJump;
 	private bool wasSliding = false;
 	private float previousXDir;
@@ -51,7 +52,7 @@ public class EntityCommandWallJump : EntityCommand<IEntityWallJumpable>
 			if (wallDir != 0)
 			{
 				// wall jump
-				GameManager.EventsPlayer.Notify(EventPlayer.OnJump);
+				Jump?.Invoke(this, EventArgs.Empty);
 
 				Entity.AnimatedSprite.FlipH = wallDir == 1; // flip sprite on wall jump
 

--- a/Scripts/Entities/Commands/EntityCommandWallJump.cs
+++ b/Scripts/Entities/Commands/EntityCommandWallJump.cs
@@ -36,7 +36,7 @@ public class EntityCommandWallJump : EntityCommand<IEntityWallJumpable>
 
 	#endregion
 
-	public event EventHandler Jump;
+	public event EventHandler WallJump;
 	private int previousWallOnJump;
 	private bool wasSliding = false;
 	private float previousXDir;
@@ -52,7 +52,7 @@ public class EntityCommandWallJump : EntityCommand<IEntityWallJumpable>
 			if (wallDir != 0)
 			{
 				// wall jump
-				Jump?.Invoke(this, EventArgs.Empty);
+				WallJump?.Invoke(this, EventArgs.Empty);
 
 				Entity.AnimatedSprite.FlipH = wallDir == 1; // flip sprite on wall jump
 

--- a/Scripts/Entities/Player/Player.cs
+++ b/Scripts/Entities/Player/Player.cs
@@ -81,7 +81,7 @@ public partial class Player : Entity, IPlayerAnimations, IPlayerCommands
 
 		// dont go under platform at the end of a dash for X ms
 		GetCommandClass<EntityCommandDash>(EntityCommandType.Dash).DashDurationDone += OnDashDone;
-		GetCommandClass<EntityCommandWallJump>(EntityCommandType.WallJump).Jump += OnJump;
+		GetCommandClass<EntityCommandWallJump>(EntityCommandType.WallJump).WallJump += OnWallJump;
 		DontCheckPlatformAfterDashDuration = new GTimer(this, 500, false, false);
 		PreventMovementTimer = new GTimer(this, new Callable(PreventMovementFinished), 250, false, false);
 
@@ -146,7 +146,7 @@ public partial class Player : Entity, IPlayerAnimations, IPlayerCommands
 	/// </summary>
 	public void OnDashDone(object _, EventArgs _2) => DontCheckPlatformAfterDashDuration.Start();
 
-	public void OnJump(object _, EventArgs _2)
+	public void OnWallJump(object _, EventArgs _2)
 	{
 		GameManager.EventsPlayer.Notify(EventPlayer.OnJump);
 


### PR DESCRIPTION
Address #185.

Let's use events to let Player do whatever it wants without impacting Commands. We use the current velocity direction for movement, so it acts as if the player is holding that direction w/o affecting other player inputs.